### PR TITLE
make sure task IDs are read as strings from json response since js cant handle 64-bit ints

### DIFF
--- a/api.js.coffee
+++ b/api.js.coffee
@@ -114,7 +114,10 @@ class root.Astrid
         if request.responseText == ""
           callback { status: "failure", message: "Empty response received from server." }
         else
-          json = Astrid.json_parse request.responseText
+          # Set 64-bit integer task IDs to strings
+          numbers = /("[^"]*":\s*)(\d{15,})([,}])/g
+          responseText = request.responseText.replace numbers, "$1\"$2\"$3"
+          json = Astrid.json_parse responseText
           callback json
     request.open "POST", url, true
     request.setRequestHeader "Content-type", "application/x-www-form-urlencoded"


### PR DESCRIPTION
This changes integer values to strings in the json response so that the 64-bit task IDs play nicely with javascript. For reference: http://myrlund.github.io/2012/07/28/64-bit-ints-in-javascript/
